### PR TITLE
prints email content to console if no mailer is provided

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -331,7 +331,11 @@ def create_user(payload: UserCreate):
                 body=email_html
             )
         except Exception as e:
-            print(f"EMAIL FAILED: {e}")
+            print(f"EMAIL FAILED: {e}. Is this intentional?")
+
+        # Print verification email contents to console if MAIL_USERNAME is not defined (For development)
+        if not MAIL_SENDER:
+            print(email_html)
 
         return dict(row)
     except IntegrityError:


### PR DESCRIPTION
Simple print email verification token to console, which could be useful for developers who don't have an email configured for SMTP use or a resend API token.