### PR TITLE
Autofill post form with teams

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1077,15 +1077,15 @@ export default function OpenMatchDashboard() {
                         }}
                       >
                         <option value="">Choose a team...</option>
-                        {teams.length > 0 ? (
-                          teams.map((team) => (
+                        {myTeams.length > 0 ? (
+                          myTeams.map((team) => (
                             <option key={team.id} value={team.id}>{team.name} ({team.sport})</option>
                           ))
                         ) : (
                           <option value="" disabled>No teams available</option>
                         )}
                       </select>
-                      {teams.length === 0 && (
+                      {myTeams.length === 0 && (
                         <p style={{ fontSize: 11, color: "#71717a", marginTop: 6 }}>
                           You need to create or join a team first.
                         </p>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -20,6 +20,21 @@ type Team = {
   city: string;
 };
 
+type ProfileSport = {
+    id: number;
+    profile_id: number;
+    sport_id: number;
+    sport_name: string;
+    mmr: number;
+    matches_played: number;
+    wins: number;
+    losses: number;
+    placement_matches_remaining: number;
+    rank_tier: string;
+    created_at: string;
+    updated_at: string;
+};
+
 type MatchPost = {
   id: number;
   user_id: number;
@@ -144,6 +159,8 @@ export default function OpenMatchDashboard() {
   const [formIsCompetitive, setFormIsCompetitive] = useState(false);
   const [myTeams, setMyTeams] = useState<MyTeam[]>([]);
   const [myTeamsLoading, setMyTeamsLoading] = useState(true);
+  const [mySports, setMySports] = useState<ProfileSport[]>([]);
+  const [mySportsLoading, setMySportsLoading] = useState(true);
 
   const [formSportId, setFormSportId] = useState<number | null>(null);
   const [formTeamId, setFormTeamId] = useState<number | null>(null);
@@ -172,8 +189,27 @@ export default function OpenMatchDashboard() {
       fetchUserPosts(currentUser.id);
       fetchRecentMatches(currentUser.id);
       fetchMyTeams(currentUser.id);
+      fetchMySports(currentUser.id)
     }
   }, []);
+
+  async function fetchMySports(userId: number) {
+    setMySportsLoading(true);
+    try {
+      const res = await fetch(`${API}/users/${userId}/profile-sports`, {
+        headers: authHeaders(),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        setMySports(data);
+      }
+    } catch (err) {
+      console.error("Failed to fetch my sports.")
+    } finally {
+      setMySportsLoading(false);
+    }
+  }
 
   async function fetchMyTeams(userId: number) {
     setMyTeamsLoading(true);
@@ -1065,9 +1101,13 @@ export default function OpenMatchDashboard() {
                         value={formSportId ?? ""}
                         onChange={(e) => setFormSportId(e.target.value ? Number(e.target.value) : null)}
                       >
-                        <option value="">Select a sport...</option>
-                        {sports.map((sport) => (
-                          <option key={sport.id} value={sport.id}>{sport.name}</option>
+                        
+                        <option value="">
+                          {mySportsLoading ? "Loading Sports..." : 
+                          ( mySports.length === 0 ? "No sports found! Please create one in your profile." : "Select a sport...")}
+                        </option>
+                          {!mySportsLoading && mySports.length>0 && mySports.map((sport) => (
+                        <option key={sport.sport_id} value={sport.sport_id}>{sport.sport_name}</option>
                         ))}
                       </select>
                     </div>


### PR DESCRIPTION
## When creating a match post on the dashboard:
* For individual posts, the sports options will only include sports the user has a sport profile for. It will provide feedback for the user to create a sport profile if they have none.
* For team posts, only the teams on which the user is a member of will be an option on the profile form